### PR TITLE
Fix imports, edit setup.py for numpy compatibility, fix deepmrseg_test entrypoint

### DIFF
--- a/DeepMRSeg/__init__.py
+++ b/DeepMRSeg/__init__.py
@@ -1,1 +1,0 @@
-print("Init DeepMRSeg")

--- a/DeepMRSeg/data_io.py
+++ b/DeepMRSeg/data_io.py
@@ -13,8 +13,8 @@ import numpy as _np
 
 _sys.path.append( _os.path.dirname( _sys.argv[0] ) )
 
-import rescaleimages
-import pythonUtilities
+from . import rescaleimages
+from . import pythonUtilities
 
 ################################################ FUNCTIONS ################################################
 

--- a/DeepMRSeg/deepmrseg_test.py
+++ b/DeepMRSeg/deepmrseg_test.py
@@ -16,11 +16,12 @@ import sys as _sys
 
 import tensorflow as _tf
 import numpy as _np
+import platform as _platform
 
 _sys.path.append( _os.path.dirname( _sys.argv[0] ) )
-import pythonUtilities
+from . import pythonUtilities
 
-from data_io import loadrespadsave
+from .data_io import loadrespadsave
 
 ################################################ FUNCTIONS ################################################
 
@@ -301,7 +302,8 @@ def _main( argv ):
 
 	### Specifying the trap signal
 	import signal as _signal
-	_signal.signal( _signal.SIGHUP, signal_handler )
+	if _platform.system() != 'Windows':
+		_signal.signal( _signal.SIGHUP, signal_handler )
 	_signal.signal( _signal.SIGINT, signal_handler )
 	_signal.signal( _signal.SIGTERM, signal_handler )
 

--- a/DeepMRSeg/deepmrseg_train.py
+++ b/DeepMRSeg/deepmrseg_train.py
@@ -14,18 +14,19 @@ import time as _time
 import signal as _signal
 import tensorflow as _tf
 import numpy as _np
+import platform as _platform
 
 _sys.path.append( _os.path.dirname( _sys.argv[0] ) )
 
-import losses
+from . import losses
 
-from data_io import checkFiles, extractPkl
-from models import create_model
-from data_augmentation import data_reader
-from optimizers import getAdamOpt, getRMSOpt, getSGDOpt, getMomentumOpt
-from layers import get_onehot
+from .data_io import checkFiles, extractPkl
+from .models import create_model
+from .data_augmentation import data_reader
+from .optimizers import getAdamOpt, getRMSOpt, getSGDOpt, getMomentumOpt
+from .layers import get_onehot
 
-import pythonUtilities
+from . import pythonUtilities
 
 ################################################ FUNCTIONS ################################################
 
@@ -165,7 +166,8 @@ def _main( argv ):
 	_sys.stdout.flush()
 
 	### Specifying the trap signal
-	_signal.signal( _signal.SIGHUP, signal_handler )
+	if _platform.system() != 'Windows':
+		_signal.signal( _signal.SIGHUP, signal_handler )
 	_signal.signal( _signal.SIGINT, signal_handler )
 	_signal.signal( _signal.SIGTERM, signal_handler )
 

--- a/DeepMRSeg/models.py
+++ b/DeepMRSeg/models.py
@@ -9,9 +9,9 @@ __EXEC_NAME__ 	= "model"
 
 import tensorflow as _tf
 
-from unet_vanilla 	import unet_vanilla, unet_vanilla_bn
-from unet_resinc 	import unet_resinc
-from unet_resnet 	import unet_resnet
+from .unet_vanilla 	import unet_vanilla, unet_vanilla_bn
+from .unet_resinc 	import unet_resinc
+from .unet_resnet 	import unet_resnet
 
 ################################################ FUNCTIONS ################################################
 

--- a/DeepMRSeg/preprocessImages_fcn.py
+++ b/DeepMRSeg/preprocessImages_fcn.py
@@ -18,7 +18,7 @@ import subprocess as _subprocess
 import nibabel as _nib
 import numpy as _np
 
-import pythonUtilities
+from . import pythonUtilities
 
 ################################################ FUNCTIONS ################################################
 

--- a/DeepMRSeg/unet_resinc.py
+++ b/DeepMRSeg/unet_resinc.py
@@ -16,7 +16,7 @@ import tensorflow as _tf
 _sys.path.append( _os.path.dirname( _sys.argv[0] ) )
 
 
-from layers import ResUnit_v1, ResInc_v1, conv_layer_resample_v1
+from .layers import ResUnit_v1, ResInc_v1, conv_layer_resample_v1
 
 ################################################ FUNCTIONS ################################################
 

--- a/DeepMRSeg/unet_resnet.py
+++ b/DeepMRSeg/unet_resnet.py
@@ -15,7 +15,7 @@ import tensorflow as _tf
 _sys.path.append( _os.path.dirname( _sys.argv[0] ) )
 
 
-from layers import ResUnit_v1, conv_layer_resample_v1
+from .layers import ResUnit_v1, conv_layer_resample_v1
 
 ################################################ FUNCTIONS ################################################
 

--- a/DeepMRSeg/unet_vanilla.py
+++ b/DeepMRSeg/unet_vanilla.py
@@ -13,8 +13,8 @@ import tensorflow as _tf
 
 _sys.path.append( _os.path.dirname( _sys.argv[0] ) )
 
-from layers import maxpool_layer, conv_layer
-from layers import conv_layer_resample_v1
+from .layers import maxpool_layer, conv_layer
+from .layers import conv_layer_resample_v1
 
 ################################################ FUNCTIONS ################################################
 

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,9 @@ setuptools.setup(
     url="https://github.com/CBICA/DeepMRSeg",
     packages=setuptools.find_packages(),
 	install_requires=[
-	'tensorflow',
-	'tensorflow-addons',
+	'tensorflow~=2.2.0',
+	'tensorflow-addons==0.11.2',
+	'numpy~=1.18.4',
 	'dill', 
 	'h5py', 
 	'hyperopt', 
@@ -29,8 +30,7 @@ setuptools.setup(
 	'pymongo',
 	'scikit-learn',
 	'seaborn',
-	'numpy',
-	'scipy', 
+    'scipy',
 	'nibabel',
 	#'subprocess',
 	#'getopt',
@@ -43,7 +43,7 @@ setuptools.setup(
 	#'shutil'
 	],
 	entry_points = {
-    'console_scripts': ['deepmrseg_train=DeepMRSeg.deepmrseg_train:runFromCMD', 'deepmrseg_test=DeepMRSeg.deepmrseg_test.runFromCMD'],
+    'console_scripts': ['deepmrseg_train=DeepMRSeg.deepmrseg_train:runFromCMD', 'deepmrseg_test=DeepMRSeg.deepmrseg_test:runFromCMD'],
     },
     classifiers=(
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Fixes:
1. Changed setup.py to require relevant versions of tensorflow, tensorflow-addons, numpy
2. Made a basic fix to the SIGHUP handling, which would've broken on windows.
3. Fixed imports in DeepMRSeg files to be relative to the current directory -- helps to ensure successful imports across different execution contexts.
4. Fixed the broken deepmrseg_test entrypoint (had a "." instead of ":").

Also emptied __init__.py -- we've tested that the init is being picked up, so we're fine. Generally, __init__.py is used to import parts of the sub-modules "ahead of time" to make importing slightly more convenient on people scripting with our package. This isn't something we really need, it'd just be a convenience feature.